### PR TITLE
Added strategy options to config + general cleanup

### DIFF
--- a/configs/latent-diffusion/cin-ldm-vq-f8-ss.yaml
+++ b/configs/latent-diffusion/cin-ldm-vq-f8-ss.yaml
@@ -69,7 +69,7 @@ model:
         embed_dim: 512
         key: class_label
 data:
-  target: main.DataModuleFromConfig
+  target: main_tpu.DataModuleFromConfig
   params:
     batch_size: 64
     num_workers: 12
@@ -87,16 +87,12 @@ data:
 
 
 lightning:
-  # trainer:
-  #   # max_steps: 100
-  #   max_epochs: 2
-  #   tpu_cores: 4
-
   trainer:
-    # checkpoint_callback: false
     benchmark: false
     devices: 4
     max_epochs: 10
-    # max_steps: 100
     log_every_n_steps: 200
     enable_progress_bar: False
+  strategy:
+    name: xla
+    sync_module_states: False


### PR DESCRIPTION
These changes will be helpful in adjusting the trainer's strategy. The motivation behind this PR is outlined in a recent change to Lightning's source code: https://github.com/Lightning-AI/lightning/pull/17522. By default, strategies that use PJRT (including `xla` strategy currently used by stable diffusion) will sync the weight values after initialization. However, this implementation of stable diffusion has a global seed defined the same for all devices, meaning that the weights will all be initialized the same. The default weight sync is unnecessary and can be skipped with the addition of `sync_module_states` from https://github.com/Lightning-AI/lightning/pull/17522. This change will save 10+ minutes of time before training waiting for the weights to syncronize.